### PR TITLE
Pinning Parcels v2.2.0 in conda command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ There are four directories:
 
 You can create a new environment named _stamm_ and including necessary modules with the following command:
 
-_conda create -n stamm -c conda-forge python=3.6 parcels spyder basemap basemap-data-hires opencv_
+_conda create -n stamm -c conda-forge python=3.6 parcels=2.2.0 spyder basemap basemap-data-hires opencv_
 
 Then, activate this environment with command _conda activate stamm_.
 


### PR DESCRIPTION
Pinning parcels to v2.2.0 in the `conda` command, so that it won't break with future parcels API changes